### PR TITLE
Refactor/cleanup

### DIFF
--- a/Bapad/Bapad/TextViewInput.cpp
+++ b/Bapad/Bapad/TextViewInput.cpp
@@ -12,7 +12,7 @@ LONG TextView::OnChar(UINT nChar, UINT nFlags)
         PostMessageW(hWnd, WM_CHAR, '\n', 1);
     if (EnterText(&ch, 1))
     {
-        NotifyParent(TVN_CHANGED);//用于通知文件被修改了
+        NotifyParent(TVN_CHANGED);//鐢ㄤ簬閫氱煡鏂囦欢琚慨鏀逛簡
     }
     return 0;
 }

--- a/Bapad/Bapad/TextViewWin32.h
+++ b/Bapad/Bapad/TextViewWin32.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 #include <CommCtrl.h>
 
 //	TextView API declared here
@@ -77,63 +77,63 @@ const size_t TXC_MAX_COLOURS = 6;			// keep this updated!
 //
 auto inline TextView_OpenFile(HWND hwndTV, wchar_t* szFile)
 {
-	return SendMessageW((hwndTV), TXM_OPENFILE, 0, (LPARAM)(szFile));
+    return SendMessageW((hwndTV), TXM_OPENFILE, 0, (LPARAM)(szFile));
 }
 
 
 auto inline TextView_Clear(HWND hwndTV)
 {
-	return SendMessageW((hwndTV), TXM_CLEAR, 0, 0);
+    return SendMessageW((hwndTV), TXM_CLEAR, 0, 0);
 }
 
 auto inline TextView_SetLineSpacing(HWND hwndTV, int nAbove, int nBelow)
 {
-	return SendMessageW((hwndTV), TXM_SETLINESPACING, (int)(nAbove), (int)(nBelow));
+    return SendMessageW((hwndTV), TXM_SETLINESPACING, (int)(nAbove), (int)(nBelow));
 }
 
 
 auto inline TextView_AddFont(HWND hwndTV, HFONT hFont, HWND g_hwndTextView)
 {
-	return SendMessageW((hwndTV), TXM_ADDFONT, (WPARAM)(HFONT)(g_hwndTextView), 0);
+    return SendMessageW((hwndTV), TXM_ADDFONT, (WPARAM)(HFONT)(g_hwndTextView), 0);
 }
 
 auto inline TextView_SetColor(HWND hwndTV, WPARAM nIdx, LPARAM rgbColor)
 {
-	return SendMessageW((hwndTV), TXM_SETCOLOR, (WPARAM)(nIdx), (LPARAM)(rgbColor));
+    return SendMessageW((hwndTV), TXM_SETCOLOR, (WPARAM)(nIdx), (LPARAM)(rgbColor));
 }
 
 
 auto inline TextView_SetStyle(HWND hwndTV, WPARAM uMask, LPARAM uStyles)
 {
-	return SendMessageW((hwndTV), TXM_SETSTYLE, (WPARAM)(uMask), (LPARAM)(uStyles));
+    return SendMessageW((hwndTV), TXM_SETSTYLE, (WPARAM)(uMask), (LPARAM)(uStyles));
 }
 
 auto inline TextView_SetStyleBool(HWND hwndTV, WPARAM uStyle, LPARAM fBoolean)
 {
-	return SendMessageW((hwndTV), TXM_SETSTYLE, (WPARAM)(uStyle), (LPARAM)(fBoolean ? uStyle : 0));
+    return SendMessageW((hwndTV), TXM_SETSTYLE, (WPARAM)(uStyle), (LPARAM)(fBoolean ? uStyle : 0));
 }
 
 auto inline TextView_SetCaretWidth(HWND hwndTV, WPARAM nWidth)
 {
-	return SendMessageW((hwndTV), TXM_SETCARETWIDTH, (WPARAM)(nWidth), 0);
+    return SendMessageW((hwndTV), TXM_SETCARETWIDTH, (WPARAM)(nWidth), 0);
 }
 
 auto inline TextView_SetImageList(HWND hwndTV, HIMAGELIST hImgList)
 {
-	return SendMessageW((hwndTV), TXM_SETIMAGELIST, (WPARAM)(HIMAGELIST)(hImgList), 0);
+    return SendMessageW((hwndTV), TXM_SETIMAGELIST, (WPARAM)(HIMAGELIST)(hImgList), 0);
 }
 
 auto inline TextView_SetLongLine(HWND hwndTV, LPARAM nLength)
 {
-	return SendMessageW((hwndTV), TXM_SETLONGLINE, (WPARAM)(0), (LPARAM)(nLength));
+    return SendMessageW((hwndTV), TXM_SETLONGLINE, (WPARAM)(0), (LPARAM)(nLength));
 }
 
 auto inline TextView_SetLineImage(HWND hwndTV, ULONG nLineNo, ULONG nImageIdx)
 {
-	return SendMessageW((hwndTV), TXM_SETLINEIMAGE, (WPARAM)(ULONG)(nLineNo), (LPARAM)(ULONG)nImageIdx);
+    return SendMessageW((hwndTV), TXM_SETLINEIMAGE, (WPARAM)(ULONG)(nLineNo), (LPARAM)(ULONG)nImageIdx);
 }
 
 auto inline TextView_GetFormat(HWND hwndTV)
 {
-	return SendMessageW((hwndTV), TXM_GETFORMAT, 0, 0);
+    return SendMessageW((hwndTV), TXM_GETFORMAT, 0, 0);
 }

--- a/Bapad/TextDocument/FormatConversion.cpp
+++ b/Bapad/TextDocument/FormatConversion.cpp
@@ -39,7 +39,7 @@ int DetectFileFormat(const unsigned char* docBuffer, const size_t docLengthByByt
 
 }
 
-size_t UTF8ToUTF32(UTF8* utf8Str, size_t utf8Len, UTF32* pch32)
+size_t UTF8ToUTF32(unsigned char* utf8Str, size_t utf8Len, unsigned long* pch32)
 {
     static ULONG nonshortest[] = { 0, 0x80, 0x800, 0x10000, 0xffffffff, 0xffffffff };
     UTF32 val32 = 0;
@@ -133,7 +133,7 @@ size_t UTF8ToUTF32(UTF8* utf8Str, size_t utf8Len, UTF32* pch32)
 
     return len;
 }
-size_t UTF32ToUTF8(UTF32 ch32, UTF8* utf8Str, size_t& utf8Len)
+size_t UTF32ToUTF8(unsigned long ch32, unsigned char* utf8Str, size_t& utf8Len)
 {
     size_t len = 0;
 
@@ -191,7 +191,7 @@ size_t UTF32ToUTF8(UTF32 ch32, UTF8* utf8Str, size_t& utf8Len)
 
 
 
-size_t AsciiToUTF16(UTF8* asciiStr, size_t asciiLen, UTF16* utf16Str, size_t& utf16Len)
+size_t AsciiToUTF16(unsigned char* asciiStr, size_t asciiLen, unsigned short* utf16Str, size_t& utf16Len)
 {
     size_t len = min(utf16Len, asciiLen);
     if (len > static_cast<size_t>((std::numeric_limits<int>::max)()))
@@ -209,7 +209,7 @@ size_t AsciiToUTF16(UTF8* asciiStr, size_t asciiLen, UTF16* utf16Str, size_t& ut
     return len;
 }
 
-size_t UTF8ToUTF16(UTF8* utf8Str, size_t utf8Len, UTF16* utf16Str, size_t& utf16Len)
+size_t UTF8ToUTF16(unsigned char* utf8Str, size_t utf8Len, unsigned short* utf16Str, size_t& utf16Len)
 {
     UTF16* utf16start = utf16Str;
     UTF8* utf8start = utf8Str;
@@ -245,7 +245,7 @@ size_t UTF8ToUTF16(UTF8* utf8Str, size_t utf8Len, UTF16* utf16Str, size_t& utf16
 
 
 
-size_t CopyUTF16(UTF16* src, size_t srcLen, UTF16* dest, size_t& destLen)
+size_t CopyUTF16(unsigned short* src, size_t srcLen, unsigned short* dest, size_t& destLen)
 {
     size_t len = min(destLen, srcLen);
     memcpy(dest, src, len * sizeof(UTF16));
@@ -258,7 +258,7 @@ size_t CopyUTF16(UTF16* src, size_t srcLen, UTF16* dest, size_t& destLen)
     return len;
 }
 
-size_t SwapUTF16(UTF16* src, size_t srcLen, UTF16* dest, size_t& destLen)
+size_t SwapUTF16(unsigned short* src, size_t srcLen, unsigned short* dest, size_t& destLen)
 {
     size_t len = min(destLen, srcLen);
 
@@ -273,7 +273,7 @@ size_t SwapUTF16(UTF16* src, size_t srcLen, UTF16* dest, size_t& destLen)
     return len;
 }
 
-size_t UTF16ToUTF32(UTF16* utf16Str, size_t utf16Len, UTF32* utf32Str, size_t& utf32Len)
+size_t UTF16ToUTF32(unsigned short* utf16Str, size_t utf16Len, unsigned long* utf32Str, size_t& utf32Len)
 {
     UTF16* utf16start = utf16Str;
     UTF32* utf32start = utf32Str;
@@ -319,7 +319,7 @@ size_t UTF16ToUTF32(UTF16* utf16Str, size_t utf16Len, UTF32* utf32Str, size_t& u
     return utf16Str - utf16start;
 }
 
-size_t UTF32ToUTF16(UTF32* utf32Str, size_t utf32Len, UTF16* utf16Str, size_t& utf16Len)
+size_t UTF32ToUTF16(unsigned long* utf32Str, size_t utf32Len, unsigned short* utf16Str, size_t& utf16Len)
 {
     UTF16* utf16start = utf16Str;
     UTF32* utf32start = utf32Str;
@@ -384,7 +384,7 @@ size_t UTF32ToUTF16(UTF32* utf32Str, size_t utf32Len, UTF16* utf16Str, size_t& u
     return utf32Str - utf32start;
 }
 
-size_t UTF16BEToUTF32(UTF16* utf16Str, size_t utf16Len, UTF32* utf32Str, size_t& utf32Len)
+size_t UTF16BEToUTF32(unsigned short* utf16Str, size_t utf16Len, unsigned long* utf32Str, size_t& utf32Len)
 {
     UTF16* utf16start = utf16Str;
     UTF32* utf32start = utf32Str;
@@ -431,7 +431,7 @@ size_t UTF16BEToUTF32(UTF16* utf16Str, size_t utf16Len, UTF32* utf32Str, size_t&
     return utf16Str - utf16start;
 }
 
-size_t UTF16ToUTF8(UTF16* utf16Str, size_t utf16Len, UTF8* utf8Str, size_t& utf8Len)
+size_t UTF16ToUTF8(unsigned short* utf16Str, size_t utf16Len, unsigned char* utf8Str, size_t& utf8Len)
 {
     UTF16* utf16start = utf16Str;
     UTF8* utf8start = utf8Str;
@@ -464,7 +464,7 @@ size_t UTF16ToUTF8(UTF16* utf16Str, size_t utf16Len, UTF8* utf8Str, size_t& utf8
 
 
 
-size_t UTF16ToAscii(UTF16* utf16Str, size_t utf16Len, UTF8* asciiStr, size_t& asciiLen)
+size_t UTF16ToAscii(unsigned short* utf16Str, size_t utf16Len, unsigned char* asciiStr, size_t& asciiLen)
 {
     size_t len = min(utf16Len, asciiLen);
     if (len > static_cast<size_t>((std::numeric_limits<int>::max)()))

--- a/Bapad/TextDocument/FormatConversion.h
+++ b/Bapad/TextDocument/FormatConversion.h
@@ -35,9 +35,9 @@ typedef unsigned char	UTF8;	// typically 8 bits
 //Byte Order Mark
 struct _BOM_LOOKUP
 {
-	DWORD  bom;
-	ULONG  headerLength;
-	int    type;
+    DWORD  bom;
+    ULONG  headerLength;
+    int    type;
 };
 
 int DetectFileFormat(const unsigned char* docBuffer, const size_t docLengthByBytes, size_t& headerSize);

--- a/Bapad/TextDocument/FormatConversion.h
+++ b/Bapad/TextDocument/FormatConversion.h
@@ -1,4 +1,4 @@
-﻿#include "pch.h"
+#include "pch.h"
 
 //unsigned,8 bits long,BYTE
 using Byte = unsigned char;
@@ -65,22 +65,22 @@ inline void BigToLittle32(char32_t& ch32)
 }
 
 
-size_t  UTF8ToUTF32(UTF8* utf8Str, size_t utf8Len, UTF32* pch32);
-size_t  UTF32ToUTF8(UTF32 ch32, UTF8* utf8Str, size_t& utf8Len);
+size_t  UTF8ToUTF32(unsigned char* utf8Str, size_t utf8Len, unsigned long* pch32);
+size_t  UTF32ToUTF8(unsigned long ch32, unsigned char* utf8Str, size_t& utf8Len);
 
 
 
-size_t  UTF8ToUTF16(UTF8* utf8Str, size_t utf8Len, UTF16* utf16Str, size_t& utf16Len);
-size_t  UTF16ToUTF8(UTF16* utf16Str, size_t utf16Len, UTF8* utf8Str, size_t& utf8Len);
+size_t  UTF8ToUTF16(unsigned char* utf8Str, size_t utf8Len, unsigned short* utf16Str, size_t& utf16Len);
+size_t  UTF16ToUTF8(unsigned short* utf16Str, size_t utf16Len, unsigned char* utf8Str, size_t& utf8Len);
 
-size_t  UTF16ToUTF32(UTF16* utf16Str, size_t utf16Len, UTF32* utf32Str, size_t& utf32Len);
-size_t  UTF32ToUTF16(UTF32* utf32Str, size_t utf32Len, UTF16* utf16Str, size_t& utf16Len);
-size_t  UTF16BEToUTF32(UTF16* utf16Str, size_t utf16Len, UTF32* utf32Str, size_t& utf32Len);
+size_t  UTF16ToUTF32(unsigned short* utf16Str, size_t utf16Len, unsigned long* utf32Str, size_t& utf32Len);
+size_t  UTF32ToUTF16(unsigned long* utf32Str, size_t utf32Len, unsigned short* utf16Str, size_t& utf16Len);
+size_t  UTF16BEToUTF32(unsigned short* utf16Str, size_t utf16Len, unsigned long* utf32Str, size_t& utf32Len);
 
-size_t  AsciiToUTF16(UTF8* asciiStr, size_t asciiLen, UTF16* utf16Str, size_t& utf16Len);
-size_t  UTF16ToAscii(UTF16* utf16Str, size_t utf16Len, UTF8* asciiStr, size_t& asciiLen);
+size_t  AsciiToUTF16(unsigned char* asciiStr, size_t asciiLen, unsigned short* utf16Str, size_t& utf16Len);
+size_t  UTF16ToAscii(unsigned short* utf16Str, size_t utf16Len, unsigned char* asciiStr, size_t& asciiLen);
 
-size_t  CopyUTF16(UTF16* src, size_t srcLen, UTF16* dest, size_t& destLen);
-size_t  SwapUTF16(UTF16* src, size_t srcLen, UTF16* dest, size_t& destLen);
+size_t  CopyUTF16(unsigned short* src, size_t srcLen, unsigned short* dest, size_t& destLen);
+size_t  SwapUTF16(unsigned short* src, size_t srcLen, unsigned short* dest, size_t& destLen);
 
 bool IsUTF8(const unsigned char* buffer, size_t len);

--- a/Bapad/TextDocument/FormatConversion.h
+++ b/Bapad/TextDocument/FormatConversion.h
@@ -68,8 +68,6 @@ inline void BigToLittle32(char32_t& ch32)
 size_t  UTF8ToUTF32(unsigned char* utf8Str, size_t utf8Len, unsigned long* pch32);
 size_t  UTF32ToUTF8(unsigned long ch32, unsigned char* utf8Str, size_t& utf8Len);
 
-
-
 size_t  UTF8ToUTF16(unsigned char* utf8Str, size_t utf8Len, unsigned short* utf16Str, size_t& utf16Len);
 size_t  UTF16ToUTF8(unsigned short* utf16Str, size_t utf16Len, unsigned char* utf8Str, size_t& utf8Len);
 

--- a/Bapad/TextDocument/MyException.h
+++ b/Bapad/TextDocument/MyException.h
@@ -2,6 +2,7 @@
 #include <stdexcept>
 #include <stdint.h>
 #include <string>
+
 class MyException : public std::runtime_error {
 public:
     enum class ConversionType
@@ -39,14 +40,12 @@ MyException::MyException(const char* message, uint32_t errorCode, ConversionType
 
 {}
 
-
 MyException::MyException(const std::string message, uint32_t errorCode, ConversionType type)
     : std::runtime_error(message),
     _errorCode(errorCode),
     _conversionType(type)
 
 {}
-
 
 
 inline uint32_t MyException::ErrorCode() const


### PR DESCRIPTION
将格式转换函数中的参数的类型别名改为原始的类型,移除部分空白行。